### PR TITLE
test: add vitest unit coverage for exif and clustering utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ data
 
 # Node dependencies
 node_modules
+node-compile-cache
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "prettier": "^3.6.2",
     "sass-embedded": "^1.93.2",
     "typescript": "^5.0.0",
-    "vitepress": "2.0.0-alpha.12"
+    "vitepress": "2.0.0-alpha.12",
+    "vitest": "^2.1.4"
   },
   "pnpm": {
     "peerDependencyRules": {

--- a/tests/unit/composables/useExifLocalization.test.ts
+++ b/tests/unit/composables/useExifLocalization.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { useExifLocalization } from '~/composables/useExifLocalization'
+
+describe('composables/useExifLocalization', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('localizeExif', () => {
+    it('delegates to the Nuxt i18n translator when a value is provided', () => {
+      const t = vi.fn((key: string) => `translated:${key}`)
+      mockNuxtImport('useNuxtApp', () => ({ $i18n: { t } }))
+
+      const { localizeExif } = useExifLocalization()
+      const result = localizeExif('colorSpace', 'sRGB')
+
+      expect(t).toHaveBeenCalledWith('exif.values.colorSpace.srgb')
+      expect(result).toBe('translated:exif.values.colorSpace.srgb')
+    })
+
+    it('returns an empty string without calling the translator when value is missing', () => {
+      const t = vi.fn()
+      mockNuxtImport('useNuxtApp', () => ({ $i18n: { t } }))
+
+      const { localizeExif } = useExifLocalization()
+      const result = localizeExif('colorSpace', undefined)
+
+      expect(result).toBe('')
+      expect(t).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/tests/unit/utils/camera.test.ts
+++ b/tests/unit/utils/camera.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { formatCameraInfo, formatLensInfo } from '~/utils/camera'
+
+describe('utils/camera', () => {
+  describe('formatCameraInfo', () => {
+    it('returns empty string when make and model are missing', () => {
+      expect(formatCameraInfo()).toBe('')
+    })
+
+    it('returns model when make is missing', () => {
+      expect(formatCameraInfo(undefined, 'ILCE-7M3')).toBe('ILCE-7M3')
+    })
+
+    it('returns make when model is missing', () => {
+      expect(formatCameraInfo('Fujifilm')).toBe('Fujifilm')
+    })
+
+    it('avoids duplicating the brand when model already contains it', () => {
+      expect(formatCameraInfo('Sony', 'ILCE-7M3')).toBe('ILCE-7M3')
+      expect(formatCameraInfo('Canon', 'EOS R5')).toBe('EOS R5')
+    })
+
+    it('combines make and model when model lacks brand information', () => {
+      expect(formatCameraInfo('Fujifilm', 'X-T5')).toBe('Fujifilm X-T5')
+    })
+  })
+
+  describe('formatLensInfo', () => {
+    it('returns empty string when lens make and model are missing', () => {
+      expect(formatLensInfo()).toBe('')
+    })
+
+    it('returns lens model when make is missing', () => {
+      expect(formatLensInfo(undefined, 'XF 23mm F1.4')).toBe('XF 23mm F1.4')
+    })
+
+    it('returns lens make when model is missing', () => {
+      expect(formatLensInfo('Sigma')).toBe('Sigma')
+    })
+
+    it('avoids duplicating the lens brand when model already contains it', () => {
+      expect(formatLensInfo('Canon', 'EF 24-70mm f/2.8L II USM')).toBe('EF 24-70mm f/2.8L II USM')
+      expect(formatLensInfo('Sony', 'FE 35mm F1.4 GM')).toBe('FE 35mm F1.4 GM')
+    })
+
+    it('combines lens make and model when model lacks brand information', () => {
+      expect(formatLensInfo('Tamron', '28-75mm F/2.8 Di III RXD')).toBe('Tamron 28-75mm F/2.8 Di III RXD')
+    })
+  })
+})

--- a/tests/unit/utils/clustering.test.ts
+++ b/tests/unit/utils/clustering.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { clusterMarkers, photosToMarkers } from '~/utils/clustering'
+import type { PhotoMarker } from '~~/shared/types/map'
+
+describe('utils/clustering', () => {
+  const createMarker = (id: string, latitude: number, longitude: number): PhotoMarker => ({
+    id,
+    latitude,
+    longitude,
+  })
+
+  describe('clusterMarkers', () => {
+    it('returns single markers without clustering at high zoom levels', () => {
+      const markers = [
+        createMarker('1', 0, 0),
+        createMarker('2', 1, 1),
+      ]
+
+      const result = clusterMarkers(markers, 16)
+
+      expect(result).toHaveLength(2)
+      result.forEach((feature, index) => {
+        expect(feature.properties.marker).toEqual(markers[index])
+        expect(feature.properties.cluster).toBeUndefined()
+        expect(feature.geometry.coordinates).toEqual([
+          markers[index].longitude,
+          markers[index].latitude,
+        ])
+      })
+    })
+
+    it('clusters nearby markers at lower zoom levels', () => {
+      const markers = [
+        createMarker('1', 0, 0),
+        createMarker('2', 0.0002, 0.0001),
+        createMarker('3', 1, 1),
+      ]
+
+      const result = clusterMarkers(markers, 8)
+
+      expect(result).toHaveLength(2)
+
+      const cluster = result.find((feature) => feature.properties.cluster)
+      expect(cluster).toBeDefined()
+      expect(cluster!.properties.point_count).toBe(2)
+      expect(cluster!.properties.clusteredPhotos).toHaveLength(2)
+
+      const single = result.find((feature) => !feature.properties.cluster)
+      expect(single).toBeDefined()
+      expect(single!.properties.marker).toEqual(markers[2])
+    })
+  })
+
+  describe('photosToMarkers', () => {
+    it('converts photos with valid coordinates into markers', () => {
+      const photos = [
+        {
+          id: '1',
+          latitude: 10,
+          longitude: 20,
+          title: 'Photo 1',
+          thumbnailUrl: 'thumb1.jpg',
+          thumbnailHash: 'hash1',
+          dateTaken: '2024-01-01',
+          city: 'City 1',
+          exif: { Make: 'Canon' },
+        },
+        {
+          id: '2',
+          latitude: null,
+          longitude: 30,
+        },
+      ]
+
+      const markers = photosToMarkers(photos as any)
+
+      expect(markers).toEqual([
+        {
+          id: '1',
+          latitude: 10,
+          longitude: 20,
+          title: 'Photo 1',
+          thumbnailUrl: 'thumb1.jpg',
+          thumbnailHash: 'hash1',
+          dateTaken: '2024-01-01',
+          city: 'City 1',
+          exif: { Make: 'Canon' },
+        },
+      ])
+    })
+  })
+})

--- a/tests/unit/utils/exif-localization.test.ts
+++ b/tests/unit/utils/exif-localization.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { toCamelCaseKey, translateExifValue } from '~/utils/exif-localization'
+
+describe('utils/exif-localization', () => {
+  describe('toCamelCaseKey', () => {
+    it('converts labels with punctuation to camelCase keys', () => {
+      expect(toCamelCaseKey('F/2.8 Lens (Test)!')).toBe('f28LensTest')
+    })
+
+    it('handles multiple spaces and mixed casing', () => {
+      expect(toCamelCaseKey('  Multi   WORD   Value ')).toBe('multiWordValue')
+    })
+  })
+
+  describe('translateExifValue', () => {
+    it('returns empty string when value is missing', () => {
+      const t = vi.fn()
+      expect(translateExifValue('colorSpace', undefined, t)).toBe('')
+      expect(t).not.toHaveBeenCalled()
+    })
+
+    it('delegates to the translation function with computed key', () => {
+      const t = vi.fn((key: string) => `translated:${key}`)
+      const result = translateExifValue('colorSpace', 'sRGB', t)
+
+      expect(t).toHaveBeenCalledTimes(1)
+      expect(t).toHaveBeenCalledWith('exif.values.colorSpace.srgb')
+      expect(result).toBe('translated:exif.values.colorSpace.srgb')
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineVitestConfig } from 'vitest/config'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineVitestConfig({
+  test: {
+    environment: 'nuxt',
+    globals: true,
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+  resolve: {
+    alias: {
+      '~': fileURLToPath(new URL('./app', import.meta.url)),
+      '@': fileURLToPath(new URL('./app', import.meta.url)),
+      '~~': fileURLToPath(new URL('.', import.meta.url)),
+      '@@': fileURLToPath(new URL('.', import.meta.url)),
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- configure Vitest with the Nuxt testing environment and workspace aliases
- add unit tests covering camera/lens formatting, EXIF localization helpers, and marker clustering
- exercise the EXIF localization composable using @nuxt/test-utils to mock the Nuxt i18n context

## Testing
- pnpm exec vitest run *(fails: Command "vitest" not found in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e2280a8844832ab09a275d7c7669f3