### PR TITLE
fix(i18n): fallback to `en` locale for unmapped locale codes

### DIFF
--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,10 +1,13 @@
 export default defineI18nConfig(() => {
   return {
     fallbackLocale: {
+      'zh-CN': ['zh-Hans'],
+      'zh-SG': ['zh-Hans'],
+      'zh': ['zh-Hans'],
       'zh-Hant': ['zh-Hant-TW', 'zh-Hant-HK'],
       'zh-TW': ['zh-Hant-TW'],
       'zh-HK': ['zh-Hant-HK'],
-      'zh': ['zh-Hans'],
+      'zh-MO': ['zh-Hant-HK'],
       'default': ['en'],
     },
   }

--- a/i18n/localeDetector.ts
+++ b/i18n/localeDetector.ts
@@ -1,20 +1,33 @@
 // Detect based on query, cookie, header
 export default defineI18nLocaleDetector((event, config) => {
+  // Supported locales from nuxt config
+  // todo this is hardcoded, maybe find a better way to sync with nuxt config
+  const SUPPORTED_LOCALES = ['zh-Hans', 'zh-Hant-TW', 'zh-Hant-HK', 'en', 'ja']
+
   // Helper function to normalize locale codes
   const normalizeLocale = (locale: string | undefined): string => {
     if (!locale) return config.defaultLocale || 'en'
 
-    // Map common locale codes to our configured locales
-    const localeMap: Record<string, string> = {
-      'zh-CN': 'zh-Hans',
-      'zh-SG': 'zh-Hans',
-      zh: 'zh-Hans',
-      'zh-TW': 'zh-Hant-TW',
-      'zh-HK': 'zh-Hant-HK',
-      'zh-MO': 'zh-Hant-HK',
+    // Check if locale exists in configured locales
+    if (SUPPORTED_LOCALES.includes(locale)) {
+      return locale
     }
 
-    return localeMap[locale] || config.defaultLocale || 'en'
+    // Try to get fallback locale from config.fallbackLocale
+    const fallbackLocales = config.fallbackLocale as
+      | Record<string, string[]>
+      | undefined
+    if (fallbackLocales && fallbackLocales[locale]) {
+      const fallbacks = fallbackLocales[locale]
+      for (const fallback of fallbacks) {
+        if (SUPPORTED_LOCALES.includes(fallback)) {
+          return fallback
+        }
+      }
+    }
+
+    // Fall back to default locale
+    return config.defaultLocale || 'en'
   }
 
   // try to get locale from query

--- a/i18n/localeDetector.ts
+++ b/i18n/localeDetector.ts
@@ -14,7 +14,7 @@ export default defineI18nLocaleDetector((event, config) => {
       'zh-MO': 'zh-Hant-HK',
     }
 
-    return localeMap[locale] || locale
+    return localeMap[locale] || 'en'
   }
 
   // try to get locale from query

--- a/i18n/localeDetector.ts
+++ b/i18n/localeDetector.ts
@@ -1,8 +1,8 @@
 // Detect based on query, cookie, header
 export default defineI18nLocaleDetector((event, config) => {
   // Helper function to normalize locale codes
-  const normalizeLocale = (locale: string | undefined): string | undefined => {
-    if (!locale) return undefined
+  const normalizeLocale = (locale: string | undefined): string => {
+    if (!locale) return config.defaultLocale || 'en'
 
     // Map common locale codes to our configured locales
     const localeMap: Record<string, string> = {
@@ -14,13 +14,13 @@ export default defineI18nLocaleDetector((event, config) => {
       'zh-MO': 'zh-Hant-HK',
     }
 
-    return localeMap[locale] || 'en'
+    return localeMap[locale] || config.defaultLocale || 'en'
   }
 
   // try to get locale from query
   const query = tryQueryLocale(event, { lang: '' }) // disable locale default value with `lang` option
   if (query) {
-    return normalizeLocale(query.toString()) || query.toString()
+    return normalizeLocale(query.toString())
   }
 
   // try to get locale from cookie
@@ -29,13 +29,13 @@ export default defineI18nLocaleDetector((event, config) => {
     name: 'chronoframe-locale',
   }) // disable locale default value with `lang` option
   if (cookie) {
-    return normalizeLocale(cookie.toString()) || cookie.toString()
+    return normalizeLocale(cookie.toString())
   }
 
   // try to get locale from header (`accept-header`)
   const header = tryHeaderLocale(event, { lang: '' }) // disable locale default value with `lang` option
   if (header) {
-    return normalizeLocale(header.toString()) || header.toString()
+    return normalizeLocale(header.toString())
   }
 
   // If the locale cannot be resolved up to this point, it is resolved with the value `defaultLocale` of the locale config passed to the function


### PR DESCRIPTION
This PR fixes #111 