### PR TITLE
Improve geolocation configuration and Nominatim support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ NUXT_PUBLIC_MAPBOX_ACCESS_TOKEN=
 # Mapbox secret access token for server-side, Mapbox Search API (Reverse Geocoding)
 NUXT_MAPBOX_ACCESS_TOKEN=
 
+# Custom Nominatim API base URL (use MapBox or proxy when official API is blocked in mainland China)
+NUXT_NOMINATIM_BASE_URL=
+
 # Storage provider (s3/local/openlist)
 NUXT_STORAGE_PROVIDER=s3
 # S3 storage provider configuration

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -69,6 +69,9 @@ export default defineNuxtConfig({
     mapbox: {
       accessToken: '',
     },
+    nominatim: {
+      baseUrl: 'https://nominatim.openstreetmap.org',
+    },
     STORAGE_PROVIDER: 's3' satisfies 's3' | 'local' | 'openlist',
     provider: {
       s3: {

--- a/server/services/location/geocoding.ts
+++ b/server/services/location/geocoding.ts
@@ -110,10 +110,14 @@ export class MapboxGeocodingProvider implements GeocodingProvider {
  * 免费的地理编码服务，适合开发和小规模使用
  */
 export class NominatimGeocodingProvider implements GeocodingProvider {
-  private readonly baseUrl = 'https://nominatim.openstreetmap.org'
+  private readonly baseUrl: string
   private readonly userAgent = 'chronoframe/1.0'
   private lastRequestTime = 0
   private readonly rateLimitMs = 1000 // Nominatim 要求至少1秒间隔
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl || useRuntimeConfig().nominatim?.baseUrl || 'https://nominatim.openstreetmap.org'
+  }
 
   async reverseGeocode(lat: number, lon: number): Promise<LocationInfo | null> {
     try {


### PR DESCRIPTION
## Fixed

- Resolved an issue where `NUXT_MAPBOX_ACCESS_TOKEN` was not taking effect.

## New Feature

- Added support for a custom Nominatim API base URL.

  **Why:**  
  The default Nominatim endpoint (`https://nominatim.openstreetmap.org`) is blocked in mainland China, which prevents Reverse Geocoding from functioning correctly when ChronoFrame is hosted there.  
  Previously, users had to rely on a MapBox token as a workaround. This new configuration provides a more affordable and flexible alternative — for example, a simple Cloudflare Worker can now serve as a proxy for Nominatim requests.
