### PR TITLE
修复docker-compose启动命令的错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ services:
 Start:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ## 📖 User Guide

--- a/README_zh.md
+++ b/README_zh.md
@@ -137,7 +137,7 @@ services:
 启动：
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 ## 📖 使用指南


### PR DESCRIPTION
- 只有使用二进制方式独立安装的docker-compose的启动命令才需要加`-`
- 常用的安装方式（包管理器和安装脚本）安装会以插件形式安装docker-compose，正确启动命令应该去掉`-`
- 结论：从`docker-compose up -d`改为`docker compose up -d`