### PR TITLE
fix: onboarding 的 storage 中表单需要支持数字类型字段

### DIFF
--- a/app/pages/onboarding/storage.vue
+++ b/app/pages/onboarding/storage.vue
@@ -26,6 +26,16 @@ const schema = computed(() => {
 
     if (field.type === 'boolean' || field.ui.type === 'toggle') {
       validator = z.boolean()
+    } else if (field.type === 'number') {
+      validator = z.number()
+      if (field.ui.required) {
+        validator = (validator as z.ZodString).min(
+          1,
+          `${field.label} is required`,
+        )
+      } else {
+        validator = (validator as z.ZodString).optional()
+      }
     } else {
       validator = z.string()
       if (field.ui.required) {


### PR DESCRIPTION
现在 maxkeys 是数字类型的，表单中只支持字符串类型，导致校验错误