### PR TITLE
fix: 相册页关闭图片查看器会刷新页面的问题

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -68,10 +68,8 @@ const handleClose = () => {
     isDirectAccess.value = false
     router.replace('/')
   } else if (returnRoute.value) {
-    // 如果有指定的返回路由，返回到该路由
-    const destination = returnRoute.value
     clearReturnRoute()
-    router.replace(destination)
+    router.back()
   } else {
     // 否则使用历史记录或默认返回首页
     if (window.history.length > 1) {


### PR DESCRIPTION
修复目前在相册路由下关闭图片查看器后，页面重载从而回到顶部和出现闪烁的问题