### PR TITLE
fix(viewer): scope photo viewer navigation to the current album

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -52,12 +52,21 @@ const { data, refresh, status } = await useFetch(() => apiEndpoint.value, {
 const photos = computed(() => (data.value as Photo[]) || [])
 
 const { switchToIndex, closeViewer, clearReturnRoute } = useViewerState()
-const { currentPhotoIndex, isViewerOpen, returnRoute, isDirectAccess } =
-  storeToRefs(useViewerState())
+const {
+  currentPhotoIndex,
+  isViewerOpen,
+  returnRoute,
+  isDirectAccess,
+  scopedPhotos,
+} = storeToRefs(useViewerState())
+
+// The photo collection the viewer actually navigates: the scoped list (e.g. an
+// album) when present, otherwise the global list.
+const viewerPhotos = computed(() => scopedPhotos.value ?? photos.value)
 
 const handleIndexChange = (newIndex: number) => {
   switchToIndex(newIndex)
-  router.replace(`/${photos.value[newIndex]?.id}`)
+  router.replace(`/${viewerPhotos.value[newIndex]?.id}`)
 }
 
 const handleClose = () => {
@@ -117,7 +126,7 @@ provide(
       </NuxtLayout>
       <ClientOnly>
         <PhotoViewer
-          :photos="photos"
+          :photos="viewerPhotos"
           :current-index="currentPhotoIndex"
           :is-open="isViewerOpen"
           @close="handleClose"

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -9,7 +9,7 @@ const route = useRoute()
 const router = useRouter()
 
 const { switchToIndex, closeViewer, openViewer } = useViewerState()
-const { isViewerOpen } = storeToRefs(useViewerState())
+const { isViewerOpen, scopedPhotos } = storeToRefs(useViewerState())
 
 const { photos } = usePhotos()
 
@@ -51,27 +51,39 @@ watch(
 
 watch(
   [photoId, photos],
-  ([currentPhotoId, currentPhotos]) => {
-    if (currentPhotoId && currentPhotos.length > 0) {
-      const foundIndex = currentPhotos.findIndex(
-        (photo) => photo.id === currentPhotoId,
-      )
-      if (foundIndex !== -1) {
-        useHead({
-          title: currentPhotos[foundIndex]?.title || $t('title.fallback.photo'),
-        })
-        if (!isViewerOpen.value) {
-          // 直接访问照片详情页时，不设置 returnRoute（传入 null）
-          openViewer(foundIndex, null)
-        } else {
-          switchToIndex(foundIndex)
-        }
-      }
-    } else if (!currentPhotoId) {
+  ([currentPhotoId, globalPhotos]) => {
+    if (!currentPhotoId) {
       closeViewer()
       useHead({
         title: '',
       })
+      return
+    }
+
+    // An already-open session (album browsing, prev/next) keeps its current
+    // photo scope; a fresh open (direct access or global gallery click) always
+    // starts from the global list, and openViewer resets the scope.
+    const activePhotos =
+      isViewerOpen.value && scopedPhotos.value
+        ? scopedPhotos.value
+        : globalPhotos
+
+    if (activePhotos.length === 0) return
+
+    const foundIndex = activePhotos.findIndex(
+      (photo) => photo.id === currentPhotoId,
+    )
+    if (foundIndex === -1) return
+
+    useHead({
+      title: activePhotos[foundIndex]?.title || $t('title.fallback.photo'),
+    })
+
+    if (!isViewerOpen.value) {
+      // Direct access to a photo detail page: don't set a returnRoute (pass null)
+      openViewer(foundIndex, null)
+    } else {
+      switchToIndex(foundIndex)
     }
   },
   { immediate: true },

--- a/app/pages/albums/[albumId].vue
+++ b/app/pages/albums/[albumId].vue
@@ -96,7 +96,9 @@ const handleOpenViewer = (index: number) => {
   if (photos && photos[index]) {
     const { openViewer } = useViewerState()
     const albumRoute = `/albums/${albumId.value}`
-    openViewer(0, albumRoute)
+    // Scope the viewer to the album's photos so prev/next stays within this album.
+    // The fetched photos are serialized rows of the same shape as Photo.
+    openViewer(index, albumRoute, photos as Photo[])
     router.push(`/${photos[index].id}`)
   }
 }

--- a/app/stores/viewer.ts
+++ b/app/stores/viewer.ts
@@ -1,12 +1,25 @@
+import type { Photo } from '~~/server/utils/db'
+
 export const useViewerState = defineStore('photo-viewer-state', () => {
   const currentPhotoIndex = ref(0)
   const isViewerOpen = ref(false)
   const returnRoute = ref<string | null>(null)
   const isDirectAccess = ref(false)
+  // The photo collection the current viewing session navigates (e.g. an album).
+  // When null, the viewer falls back to the global photo list.
+  const scopedPhotos = ref<Photo[] | null>(null)
 
-  const openViewer = (index: number, route?: string | null) => {
+  const openViewer = (
+    index: number,
+    route?: string | null,
+    photos?: Photo[] | null,
+  ) => {
     currentPhotoIndex.value = index
     isViewerOpen.value = true
+    // Every open resets the scope: album-like contexts pass an explicit photo
+    // collection, while the global gallery / direct access pass null (or omit
+    // it) to fall back to the global list.
+    scopedPhotos.value = photos ?? null
     if (route) {
       returnRoute.value = route
       isDirectAccess.value = false
@@ -32,6 +45,7 @@ export const useViewerState = defineStore('photo-viewer-state', () => {
     isViewerOpen,
     returnRoute,
     isDirectAccess,
+    scopedPhotos,
     openViewer,
     switchToIndex,
     closeViewer,


### PR DESCRIPTION
## Problem

Opening a photo from inside an album launched the **global** photo viewer: prev/next navigated through all photos instead of staying within the album.

## Cause

The viewer is a single global instance (`app.vue`) bound to the global photo list. Opening a photo navigates to the global `/:photoId` route, which resolved the index against — and fed the viewer — the global list. There was no notion of an album-scoped collection (the album handler even passed a hardcoded index `0`).

## Fix

- Add a `scopedPhotos` collection to the viewer store; `openViewer(index, route?, photos?)` sets it (or resets to `null`).
- The album page passes its photo list; the global gallery / direct access pass `null` to fall back to the global list.
- `app.vue` and the photo route resolve indices against the scoped list while a session is open, and reset to the global list on a fresh open.

## Verification

No test harness exists in the repo, so verified via `oxlint` (clean), `oxfmt --check` (clean), `nuxi typecheck` (no net-new errors), and manual tracing of the album, global-gallery, album→global, and direct-deep-link flows.

## AI Disclosure

Claude Code was used during the work on this PR. All code was manually verified, and I conducted UI verification too, ensuring the desired behavior is reached.