### PR TITLE
fix(storage): 修复 OpenList/115 CDN 图片跨域加载失败

### DIFF
--- a/app/components/Histogram.vue
+++ b/app/components/Histogram.vue
@@ -5,6 +5,7 @@ import {
   drawHistogramToCanvas,
   type HistogramDataCompressed,
 } from '~/libs/histogram'
+import { resolveImageUrl } from '~/utils/image-url'
 
 const props = defineProps<{
   thumbnailUrl: string
@@ -40,9 +41,8 @@ watchEffect(() => {
 
   const img = new Image()
   currentImage = img
-  img.crossOrigin = 'anonymous'
 
-  const url = new URL(props.thumbnailUrl, window.location.origin)
+  const url = new URL(resolveImageUrl(props.thumbnailUrl), window.location.origin)
   url.searchParams.set('_cors', Date.now().toString())
   img.src = url.toString()
 

--- a/app/components/photo/ProgressiveImage.vue
+++ b/app/components/photo/ProgressiveImage.vue
@@ -2,6 +2,7 @@
 import { WebGLImageViewer } from '@chronoframe/webgl-image'
 import type { LoadingIndicatorRef } from './LoadingIndicator.vue'
 import type { ImageLoaderManager } from '~/libs/image-loader-manager'
+import { resolveImageUrl } from '~/utils/image-url'
 
 interface Props {
   src: string
@@ -82,18 +83,18 @@ const showWebGLViewer = computed(() => {
 
 const loadImage = () => {
   loaderManagerRef.value = useImageLoader(
-    props.src,
-    props.isCurrentImage,
-    highResLoaded.value,
-    hasError.value,
-    props.loadingIndicatorRef,
-    props.onProgress,
-    props.onError,
-    (src) => (currentSrc.value = src),
-    (loaded) => (highResLoaded.value = loaded),
-    (error) => (hasError.value = error),
-    (rendered) => (highResRendered.value = rendered),
-    props.onImageLoaded,
+      resolveImageUrl(props.src),
+      props.isCurrentImage,
+      highResLoaded.value,
+      hasError.value,
+      props.loadingIndicatorRef,
+      props.onProgress,
+      props.onError,
+      (src) => (currentSrc.value = src),
+      (loaded) => (highResLoaded.value = loaded),
+      (error) => (hasError.value = error),
+      (rendered) => (highResRendered.value = rendered),
+      props.onImageLoaded,
   )
 }
 

--- a/app/components/photo/ShareModal.vue
+++ b/app/components/photo/ShareModal.vue
@@ -1,5 +1,6 @@
 <script lang="ts" setup>
 import { motion, AnimatePresence } from 'motion-v'
+import { resolveImageUrl } from '~/utils/image-url'
 
 interface Props {
   isOpen: boolean
@@ -257,7 +258,7 @@ const downloadOgImage = async () => {
 
 const downloadOriginalImage = async () => {
   try {
-    const response = await fetch(props.photo.originalUrl!)
+    const response = await fetch(resolveImageUrl(props.photo.originalUrl!))
     const blob = await response.blob()
     const url = window.URL.createObjectURL(blob)
     const link = document.createElement('a')

--- a/app/composables/useLivePhotoProcessor.ts
+++ b/app/composables/useLivePhotoProcessor.ts
@@ -1,4 +1,5 @@
 import { ref, computed } from 'vue'
+import { resolveImageUrl } from '~/utils/image-url'
 
 interface LivePhotoProcessingState {
   isProcessing: boolean
@@ -90,7 +91,7 @@ export const useLivePhotoProcessor = () => {
       const controller = new AbortController()
       const timeoutId = setTimeout(() => controller.abort(), 30000) // 30秒超时
 
-      const response = await fetch(movUrl, {
+      const response = await fetch(resolveImageUrl(movUrl), {
         signal: controller.signal,
         headers: {
           'Cache-Control': 'max-age=3600', // 缓存1小时

--- a/app/libs/image-loader-manager.ts
+++ b/app/libs/image-loader-manager.ts
@@ -164,7 +164,7 @@ export class ImageLoaderManager {
       isVisible: false,
     })
     return {
-      blobSrc: originalUrl,
+      blobSrc: url,
     }
   }
 

--- a/app/pages/dashboard/photos.vue
+++ b/app/pages/dashboard/photos.vue
@@ -4,6 +4,7 @@ import type { Photo, PipelineQueueItem } from '~~/server/utils/db'
 import { h, resolveComponent } from 'vue'
 import { Icon, UBadge } from '#components'
 import ThumbImage from '~/components/ui/ThumbImage.vue'
+import { resolveImageUrl } from '~/utils/image-url'
 
 const UCheckbox = resolveComponent('UCheckbox')
 const Rating = resolveComponent('Rating')
@@ -1976,7 +1977,7 @@ const handleBatchDownload = async () => {
   try {
     for (const photo of photosWithUrl) {
       try {
-        const response = await fetch(photo.originalUrl!)
+        const response = await fetch(resolveImageUrl(photo.originalUrl!))
         if (!response.ok) {
           failureCount++
           continue

--- a/app/utils/image-url.ts
+++ b/app/utils/image-url.ts
@@ -1,0 +1,17 @@
+/**
+ * 将外部图片 URL 转换为同源代理地址，绕过浏览器 CORS 限制。
+ * - 同源 / 相对路径（/storage、/thumb 等）原样返回
+ * - blob: / data: 原样返回
+ * - 外部 URL 转为 /proxy-image?url=...
+ */
+export const resolveImageUrl = (url: string): string => {
+  if (!url) return url
+  try {
+    const parsed = new URL(url, window.location.origin)
+    if (parsed.protocol === 'blob:' || parsed.protocol === 'data:') return url
+    if (parsed.origin === window.location.origin) return url
+    return `/proxy-image?url=${encodeURIComponent(url)}`
+  } catch {
+    return url
+  }
+}

--- a/server/routes/proxy-image.get.ts
+++ b/server/routes/proxy-image.get.ts
@@ -1,0 +1,50 @@
+import { Readable } from 'node:stream'
+
+export default eventHandler(async (event) => {
+  const { url } = getQuery(event)
+  if (typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid url' })
+  }
+
+  // 只允许代理已配置存储提供方的主机，防止开放代理/SSRF
+  const runtimeConfig = useRuntimeConfig()
+  const hosts: string[] = []
+  const openlist = runtimeConfig.provider?.openlist as
+    | { baseUrl?: string; cdnUrl?: string }
+    | undefined
+  const s3 = runtimeConfig.provider?.s3 as { cdnUrl?: string } | undefined
+  if (openlist?.baseUrl) hosts.push(new URL(openlist.baseUrl).hostname)
+  if (openlist?.cdnUrl) hosts.push(new URL(openlist.cdnUrl).hostname)
+  if (s3?.cdnUrl) hosts.push(new URL(s3.cdnUrl).hostname)
+
+  let hostname = ''
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid url' })
+  }
+  if (hosts.length > 0 && !hosts.includes(hostname)) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden host' })
+  }
+
+  // Node fetch 默认跟随 302 重定向（OpenList → 115 CDN）
+  const upstream = await fetch(url, { redirect: 'follow' })
+  if (!upstream.ok) {
+    throw createError({
+      statusCode: upstream.status,
+      statusMessage: 'Upstream fetch failed',
+    })
+  }
+
+  const contentType =
+    upstream.headers.get('content-type') || 'application/octet-stream'
+  const contentLength = upstream.headers.get('content-length')
+  setHeader(event, 'Content-Type', contentType)
+  setHeader(event, 'Cache-Control', 'public, max-age=86400')
+  if (contentLength) {
+    setHeader(event, 'Content-Length', contentLength)
+  }
+
+  // 流式转发，避免大图/视频占用内存
+  return sendStream(event, Readable.fromWeb(upstream.body as any))
+})


### PR DESCRIPTION
问题:浏览器端 XHR/fetch 直接请求 OpenList(/d/) 时被 302
重定向到 115 CDN,而 CDN 不返回 Access-Control-Allow-Origin, 导致查看器大图、直方图、下载、LivePhoto 等功能全部失败。

方案:新增同源代理路由 /proxy-image,由服务端 Node fetch
跟随 302 获取文件后流式转发;前端所有跨域 XHR/fetch/canvas
请求统一改写为 /proxy-image?url=...。

- 新增 server/routes/proxy-image.get.ts:同源代理路由, 带存储主机白名单校验(防 SSRF),流式转发 + 缓存头
- 新增 app/utils/image-url.ts:resolveImageUrl() 工具, 外部 URL 改写为 /proxy-image,同源/blob/data 原样返回
- fix(app/components/photo/ProgressiveImage.vue):原图 加载 XHR 走代理(修复主报错路径)
- fix(app/libs/image-loader-manager.ts):processNormalImage 返回 blob URL 而非 originalUrl,避免 WebGL 解码二次跨域
- fix(app/components/Histogram.vue):移除 crossOrigin= 'anonymous' 并走代理,canvas 不再被污染
- fix(app/components/photo/ShareModal.vue):下载原图走代理
- fix(app/pages/dashboard/photos.vue):批量下载走代理
- fix(app/composables/useLivePhotoProcessor.ts):LivePhoto MOV 抓取走代理"