### PR TITLE
fix(albums): hide photos shared with a hidden album from anonymous viewers

### DIFF
--- a/server/api/albums/[albumId]/index.get.ts
+++ b/server/api/albums/[albumId]/index.get.ts
@@ -1,5 +1,7 @@
-import { asc, getTableColumns } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import z from 'zod'
+
+import { fetchAlbumPhotos } from '../../../utils/album-visibility'
 
 export default eventHandler(async (event) => {
   const { albumId } = await getValidatedRouterParams(
@@ -28,39 +30,20 @@ export default eventHandler(async (event) => {
   }
 
   // 检查相册是否隐藏，如果隐藏则需要用户登录才能访问
-  if (album.isHidden) {
-    const session = await getUserSession(event)
-    if (!session.user) {
-      throw createError({
-        statusCode: 404,
-        statusMessage: 'Album not found',
-      })
-    }
-  }
+  const session = await getUserSession(event)
+  const isLoggedIn = Boolean(session.user)
 
-  // 获取相册中的照片
-  const photos = await db
-    // all fields from tables.photos
-    .select({
-      ...getTableColumns(tables.photos),
+  if (album.isHidden && !isLoggedIn) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: 'Album not found',
     })
-    .from(tables.photos)
-    .innerJoin(
-      tables.albumPhotos,
-      eq(tables.photos.id, tables.albumPhotos.photoId),
-    )
-    .where(eq(tables.albumPhotos.albumId, albumId))
-    .orderBy(asc(tables.albumPhotos.position))
-    .all()
-
-  // 验证相册数据完整性
-  if (!photos || !Array.isArray(photos)) {
-    // 空相册也是合法的，只需要返回空数组
-    return {
-      ...album,
-      photos: [],
-    }
   }
+
+  // Anonymous viewers must not see photos that are also members of any
+  // hidden album — otherwise a photo shared between a public and a hidden
+  // album would leak through the public album (see issue #299).
+  const photos = await fetchAlbumPhotos(db, tables, albumId, isLoggedIn)
 
   return {
     ...album,

--- a/server/utils/album-visibility.ts
+++ b/server/utils/album-visibility.ts
@@ -1,0 +1,56 @@
+import { asc, eq, getTableColumns } from 'drizzle-orm'
+import type { useDB } from './db'
+import type * as schema from '../database/schema'
+
+/**
+ * Returns the photos of a given album, optionally stripping those that also
+ * appear in any hidden album (so anonymous viewers cannot reach them via a
+ * public album).
+ *
+ * Kept as a small pure helper so the visibility contract can be exercised
+ * from tests without spinning up the Nitro event-handler runtime. The
+ * production handler in `server/api/albums/[albumId]/index.get.ts` delegates
+ * to this helper.
+ */
+export async function fetchAlbumPhotos(
+  db: ReturnType<typeof useDB>,
+  tables: typeof schema,
+  albumId: number,
+  loggedIn: boolean,
+) {
+  const rows = await db
+    .select({
+      ...getTableColumns(tables.photos),
+    })
+    .from(tables.photos)
+    .innerJoin(
+      tables.albumPhotos,
+      eq(tables.photos.id, tables.albumPhotos.photoId),
+    )
+    .where(eq(tables.albumPhotos.albumId, albumId))
+    .orderBy(asc(tables.albumPhotos.position))
+    .all()
+
+  if (loggedIn) {
+    return rows
+  }
+
+  const hiddenPhotoIds = (
+    await db
+      .select({ photoId: tables.albumPhotos.photoId })
+      .from(tables.albumPhotos)
+      .innerJoin(
+        tables.albums,
+        eq(tables.albumPhotos.albumId, tables.albums.id),
+      )
+      .where(eq(tables.albums.isHidden, true))
+      .all()
+  ).map((r: { photoId: string }) => r.photoId)
+
+  if (hiddenPhotoIds.length === 0) {
+    return rows
+  }
+
+  const hidden = new Set(hiddenPhotoIds)
+  return rows.filter((row: { id: string }) => !hidden.has(row.id))
+}


### PR DESCRIPTION
Fixes #299

## Summary

When a photo is a member of both a public album and a hidden album, the public album previously returned that photo (and counted it) for unauthenticated viewers. The sibling endpoint `GET /api/photos` (`server/api/photos/visible.get.ts`) already excluded any photo that belongs to a hidden album, so the public album's photo list and count were inconsistent with the rest of the app — and opening the leaked photo would redirect into the hidden album.

This change makes `GET /api/albums/[albumId]` apply the same rule: anonymous viewers only see photos that are not members of any hidden album. Logged-in users keep seeing every photo in every album they can access (matching the existing `isHidden` 404 behaviour).

## Changes

- `server/utils/album-visibility.ts` (new): `fetchAlbumPhotos(db, tables, albumId, loggedIn)` — performs the album-photos join and excludes hidden-album members for anonymous viewers.
- `server/api/albums/[albumId]/index.get.ts`: delegates the photo fetch to the helper, threading the existing session flag through.

## Verification

Verified with an in-memory SQLite harness mirroring the join used by the endpoint:

- anonymous viewer of a public album that shares a photo with a hidden album: the shared photo no longer appears and the photo count drops accordingly (on `main` the leaked photo is listed);
- photo positions of the remaining photos are preserved;
- logged-in users still see every photo (unchanged).

Reproduction of the original issue:

1. Create album A (public) and album B (`is_hidden = true`).
2. Add a photo P to both albums.
3. As an anonymous viewer, open album A: P is listed and counted even though it is hidden from `/api/photos`.

## Compatibility

- Anonymous behaviour is now strictly more restrictive (it stops leaking).
- Authenticated behaviour is unchanged.
- Response shape is unchanged (`Album & { photos: Photo[] }`).

oxlint clean on changed files.

Signed-off-by: simonyang08 <ppt5928@gmail.com>